### PR TITLE
eng_back: Fix compiler warning for 32-bit

### DIFF
--- a/src/eng_back.c
+++ b/src/eng_back.c
@@ -547,7 +547,7 @@ static void *ctx_try_load_object(ENGINE_CTX *ctx,
 						goto error;
 					}
 				} else {
-					ctx_log(ctx, 0, "Multiple matching slots (%lu); will not try to"
+					ctx_log(ctx, 0, "Multiple matching slots (%zu); will not try to"
 						" login\n", matched_count);
 					for (m = 0; m < matched_count; m++){
 						slot = matched_slots[m];


### PR DESCRIPTION
Amend printf formatter to avoid following compiler warning when building for 32-bit:

  .../src/eng_back.c:550:85: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'size_t' {aka 'unsigned int'} [-Wformat=]